### PR TITLE
[BEAR-2546]: Bear 2546 google timezone sync

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -581,7 +581,7 @@ class RNGoogleFit {
     return result;
   }
 
-  getRestingHeartRateSamples = async (options) => {
+  getRestingHeartRateSamples = async (options, inLocalTimeZone = false) => {
     const { startDate, endDate, bucketInterval, bucketUnit } = prepareInput(options);
     const result = await googleFit.getRestingHeartRateSamples(
       startDate,
@@ -590,12 +590,12 @@ class RNGoogleFit {
       bucketUnit
     );
     if (result.length > 0) {
-      return prepareResponse(result, 'value');
+      return prepareResponse(result, 'value', inLocalTimeZone);
     }
     return result;
   }
 
-  getBloodPressureSamples = async (options, callback) => {
+  getBloodPressureSamples = async (options, inLocalTimeZone = false) => {
     const { startDate, endDate, bucketInterval, bucketUnit } = prepareInput(options);
     const result = await googleFit.getBloodPressureSamples(
       startDate,
@@ -604,7 +604,7 @@ class RNGoogleFit {
       bucketUnit,
     );
     if (result.length > 0) {
-      return prepareResponse(result, 'systolic');
+      return prepareResponse(result, 'systolic', inLocalTimeZone);
     }
     return result;
   }
@@ -623,7 +623,7 @@ class RNGoogleFit {
     return result;
   }
 
-  getBodyTemperatureSamples = async (options, callback) => {
+  getBodyTemperatureSamples = async (options, inLocalTimeZone = false) => {
     const { startDate, endDate, bucketInterval, bucketUnit } = prepareInput(options);
     const result = await googleFit.getBodyTemperatureSamples(
       startDate,
@@ -632,7 +632,7 @@ class RNGoogleFit {
       bucketUnit,
     );
     if (result.length > 0) {
-      return prepareResponse(result);
+      return prepareResponse(result, inLocalTimeZone);
     }
     return result;
   }


### PR DESCRIPTION
This PR adds `inLocalTimeZone` to `getRestingHeartRateSamples`, `getBloodPressureSamples` and `getBodyTemperatureSamples`. 

This change allows us to sync with Google Fit taking into account the users current timezone. If a user in UCT+11 was to sync their Google Fit data as "endDate":"2024-01-15T07:00:00.000Z", the values would be returned as "endDate":"2022-01-14T:21:00.000Z" once the timezone has been synced. 

This PR is backwards compatible as the current default for `inlocalTimezone` is `false`. 
I've also removed `callback` from these functions as they're not currently used.