### PR TITLE
[BEAR-2638]: Remove AndroidX

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,12 +77,9 @@ dependencies {
     implementation('com.facebook.react:react-native:+') {
         exclude group: 'com.android.support'
     }
-    if (supportLibVersion && androidXVersion == null) {
-        implementation "com.android.support:appcompat-v7:$supportLibVersion"
-    } else {
-        def defaultAndroidXVersion = "1.+"
-        implementation "androidx.appcompat:appcompat:${safeExtGet(androidXVersion, defaultAndroidXVersion)}"
-    }
+       
+    implementation "com.android.support:appcompat-v7:$supportLibVersion"
+
     implementation "com.google.android.gms:play-services-auth:${safeExtGet('authVersion', '+')}"
     implementation "com.google.android.gms:play-services-fitness:${safeExtGet('fitnessVersion', '+')}"
 }


### PR DESCRIPTION
AndroidX would mean us needing to upgrade our minSDK version from 33 to 34.
Which in tern would mean we have to upgrade our version of Gradle.

This PR temporarily removes AndroidX, we should look to re-add this again in the future.