### PR TITLE
[BEAR-2638]: Update and remove duplicate types

### DIFF
--- a/index.android.d.ts
+++ b/index.android.d.ts
@@ -131,22 +131,19 @@ declare module 'react-native-google-fit' {
       inLocalTimeZone: boolean
     ) => Promise<AggregatedHeartRateResponse[]>
 
-    getAggregatedHeartRateSamples: (
-      options: StartAndEndDate & Partial<BucketOptions>,
-      inLocalTimeZone: boolean
-    ) => Promise<AggregatedHeartRateResponse[]>;
-
     /**
      * Query for getting resting heart rate samples. the options object is used to setup a query to retrieve relevant samples.
      * @param {Object} options  getRestingHeartRateSamples accepts an options object startDate: ISO8601Timestamp and endDate: ISO8601Timestamp.
      *
      */
     getRestingHeartRateSamples: (
-      options: StartAndEndDate & Partial<BucketOptions>
+      options: StartAndEndDate & Partial<BucketOptions>,
+      inLocalTimeZone: boolean
     ) => Promise<HeartRateResponse[]>
 
     getBloodPressureSamples: (
-      options: StartAndEndDate & Partial<BucketOptions>
+      options: StartAndEndDate & Partial<BucketOptions>,
+      inLocalTimeZone: boolean
     ) => Promise<BloodPressureResponse[]>
 
     getBloodGlucoseSamples: (
@@ -154,7 +151,8 @@ declare module 'react-native-google-fit' {
     ) => Promise<BloodGlucoseResponse[]>
 
     getBodyTemperatureSamples: (
-      options: StartAndEndDate & Partial<BucketOptions>
+      options: StartAndEndDate & Partial<BucketOptions>,
+      inLocalTimeZone: boolean
     ) => Promise<BodyTemperatureResponse[]>
 
     getOxygenSaturationSamples: (
@@ -374,15 +372,6 @@ declare module 'react-native-google-fit' {
     average: number
     max: number
     day: Day
-  }
-
-  export type AggregatedHeartRateResponse = {
-    startDate: string,
-    endDate: string,
-    min: number,
-    average: number,
-    max: number,
-    day: Day,
   }
 
   export type BloodPressureResponse = {


### PR DESCRIPTION
This PR updates the types to use `inLocalTimeZone` and also removes duplicate types.